### PR TITLE
Export pluginlib as a transitive dependency

### DIFF
--- a/nodelet/CMakeLists.txt
+++ b/nodelet/CMakeLists.txt
@@ -1,39 +1,26 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(nodelet)
 
-# Nodelet is known not to build and run correctly on 
-# OS X Lion 10.7.x using the llvm.  Use gcc-4.2 instead (if available).
-# See: https://code.ros.org/trac/ros-pkg/ticket/5144
-if(${CMAKE_SYSTEM} MATCHES "Darwin-11.*")
-  if(EXISTS "/usr/bin/g++-4.2" AND EXISTS "/usr/bin/gcc-4.2")
-    set(CMAKE_CXX_COMPILER /usr/bin/g++-4.2)
-    set(CMAKE_C_COMPILER /usr/bin/gcc-4.2)
-  else()
-    # If there is no g++-4.2 or gcc-4.2 use clang++ and clang
-    set(CMAKE_CXX_COMPILER /usr/bin/clang++)
-    set(CMAKE_C_COMPILER /usr/bin/clang)
-  endif()
-endif()
-
-# Find common packages
-find_package(Boost)
+## Find catkin dependencies
 find_package(catkin REQUIRED bondcpp message_generation pluginlib rosconsole roscpp std_msgs)
-include_directories(SYSTEM ${catkin_INCLUDE_DIRS}
-                           ${BOOST_INCLUDE_DIRS}
-)
-include_directories(include)
 
-# Deal with the services
+## Find Boost (only headers)
+find_package(Boost REQUIRED)
+
+## Add service files to be generated
 add_service_files(DIRECTORY srv FILES NodeletList.srv  NodeletLoad.srv  NodeletUnload.srv)
 
+## Generate servics
 generate_messages(DEPENDENCIES std_msgs)
 
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES nodeletlib uuid
-  CATKIN_DEPENDS bondcpp message_runtime rosconsole roscpp std_msgs
+  CATKIN_DEPENDS bondcpp message_runtime pluginlib rosconsole roscpp std_msgs
   DEPENDS Boost
 )
+
+include_directories(include ${catkin_INCLUDE_DIRS} ${BOOST_INCLUDE_DIRS})
 
 # Debug only, collects stats on how callbacks are doled out to worker threads
 #add_definitions(-DNODELET_QUEUE_DEBUG)
@@ -44,11 +31,6 @@ add_dependencies(nodeletlib ${nodelet_EXPORTED_TARGETS})
 
 add_executable(nodelet src/nodelet.cpp)
 target_link_libraries(nodelet nodeletlib uuid ${catkin_LIBRARIES} ${BOOST_LIBRARIES})
-
-# See: https://code.ros.org/trac/ros-pkg/ticket/5144
-if(APPLE)
-  set_target_properties(nodeletlib PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
-endif(APPLE)
 
 # install
 install(DIRECTORY include/${PROJECT_NAME}/

--- a/nodelet/package.xml
+++ b/nodelet/package.xml
@@ -33,6 +33,7 @@
   <run_depend>bondcpp</run_depend>
   <run_depend>boost</run_depend>
   <run_depend>message_runtime</run_depend>
+  <run_depend>pluginlib</run_depend>
   <run_depend>rosconsole</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>


### PR DESCRIPTION
Also remove some old Apple specific rules which
are no longer required.

We might consider back porting this to groovy?

I discovered this when refactoring the tutorials, others who ran into this might have just added an explicit dependency on class_loader to solve it.
