### PR TITLE
exit if Loader::load returns failure in "standalone" mode instead of continuing to run

### DIFF
--- a/nodelet/src/nodelet.cpp
+++ b/nodelet/src/nodelet.cpp
@@ -304,7 +304,9 @@ int
     ros::M_string remappings; //Remappings are already applied by ROS no need to generate them.
     std::string nodelet_name = ros::this_node::getName ();
     std::string nodelet_type = arg_parser.getType();
-    n.load(nodelet_name, nodelet_type, remappings, arg_parser.getMyArgv());
+    if(!n.load(nodelet_name, nodelet_type, remappings, arg_parser.getMyArgv()))
+      return -1;
+
     ROS_DEBUG("Successfully loaded nodelet of type '%s' into name '%s'\n", nodelet_name.c_str(), nodelet_name.c_str());
 
     ros::spin();


### PR DESCRIPTION
The current behavior creates problems, for example: when running a standalone nodelet whose `onInit` method throws a `std::runtime_error`, the nodelet runner never exits, and is never relaunched by a launch file.
