### PR TITLE
Correctly check that there are enough arguments when nodelet is launched...

### DIFF
--- a/nodelet/src/nodelet.cpp
+++ b/nodelet/src/nodelet.cpp
@@ -104,20 +104,17 @@ class NodeletArgumentParsing
         }
       }
 
-      if (non_ros_args.size() > 2)
+      else if (command_ == "unload" && non_ros_args.size() > 3)
       {
-        if (command_ == "unload")
-        {
-          name_    = non_ros_args[2];
-          manager_ = non_ros_args[3];
-          used_args = 4;
-        }
-        else if (command_ == "standalone")
-        {
-          type_ = non_ros_args[2];
-          printf("type is %s\n", type_.c_str());
-          used_args = 3;
-        }
+	name_    = non_ros_args[2];
+	manager_ = non_ros_args[3];
+	used_args = 4;
+      }
+      else if (command_ == "standalone" && non_ros_args.size() > 2)
+      {
+	type_ = non_ros_args[2];
+	printf("type is %s\n", type_.c_str());
+	used_args = 3;
       }
 
       if (command_ == "manager")


### PR DESCRIPTION
... with the unload command

Currently the node will segfault if the following is run
rosrun nodelet nodelet unload name
