### PR TITLE
Fixed missing header

### DIFF
--- a/nodelet/include/nodelet/detail/callback_queue_manager.h
+++ b/nodelet/include/nodelet/detail/callback_queue_manager.h
@@ -30,6 +30,8 @@
 #ifndef NODELET_CALLBACK_QUEUE_MANAGER_H
 #define NODELET_CALLBACK_QUEUE_MANAGER_H
 
+#include <ros/types.h>
+
 #include <boost/shared_ptr.hpp>
 #include <boost/scoped_array.hpp>
 #include <boost/unordered_map.hpp>


### PR DESCRIPTION
When compiling from source on Debian got errors about the use of uint32_t type. Including ros/types.h solves the problem.
