### PR TITLE
nodelet: Loader: do not call impl->refresh_classes_ if not available

### DIFF
--- a/nodelet/src/loader.cpp
+++ b/nodelet/src/loader.cpp
@@ -267,6 +267,14 @@ bool Loader::load(const std::string &name, const std::string& type, const ros::M
   }
   catch (std::runtime_error& e)
   {
+    // If we cannot refresh the nodelet cache, fail immediately
+    if(!impl_->refresh_classes_)
+    {
+      ROS_ERROR("Failed to load nodelet [%s] of type [%s]: %s", name.c_str(), type.c_str(), e.what());
+      return false;
+    }
+
+    // otherwise, refresh the cache and try again.
     try
     {
       impl_->refresh_classes_();

--- a/test_nodelet/CMakeLists.txt
+++ b/test_nodelet/CMakeLists.txt
@@ -35,4 +35,7 @@ if(CATKIN_ENABLE_TESTING)
   target_link_libraries(benchmark ${BOOST_LIBRARIES}
                                   ${PROJECT_NAME}
   )
+
+  add_executable(create_instance_cb_error src/create_instance_cb_error.cpp)
+  target_link_libraries(create_instance_cb_error ${catkin_LIBRARIES})
 endif()

--- a/test_nodelet/src/create_instance_cb_error.cpp
+++ b/test_nodelet/src/create_instance_cb_error.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2011, Willow Garage, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Helper for issue #23: nodelet loader hides load error
+// should generate a helpful error message containing "NODELET_TEST_FAILURE"
+
+#include <nodelet/loader.h>
+#include <ros/init.h>
+
+#include <boost/bind.hpp>
+
+boost::shared_ptr<nodelet::Nodelet> create_instance(const std::string& lookup_name)
+{
+    throw std::runtime_error("NODELET_TEST_FAILURE");
+}
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "simple_loader");
+
+    nodelet::Loader loader(boost::bind(&create_instance, _1));
+    std::map<std::string, std::string> remappings;
+    std::vector<std::string> my_argv;
+    if(!loader.load("/fail", "test_nodelet/FailingNodelet", remappings, my_argv))
+        return 1;
+
+    return 0;
+}

--- a/test_nodelet/test/test_loader.py
+++ b/test_nodelet/test/test_loader.py
@@ -33,6 +33,7 @@ import rospy
 import unittest
 import rostest
 import random
+import subprocess
 
 from nodelet.srv import *
 
@@ -86,6 +87,17 @@ class TestLoader(unittest.TestCase):
         req.name = "/my_nodelet"
         self.assertRaises(rospy.ServiceException, unload.call, req)
 
+    def test_loader_error_message(self):
+        proc = subprocess.Popen(["rosrun", "test_nodelet", "create_instance_cb_error"],
+            stderr=subprocess.PIPE
+        )
+
+        # The load should fail
+        self.assertEqual(proc.wait(), 1)
+
+        # And the loader should print our error message
+        out = proc.stderr.read()
+        self.assertIn('NODELET_TEST_FAILURE', out)
 
 if __name__ == '__main__':
     rospy.init_node('test_loader')


### PR DESCRIPTION
This fixes #23. The call on an uninitialized boost::function was causing
an exception, which was reported to the user instead of the underlying
exception from the failed library load.
