### PR TITLE
nodelet loader: display error messages from both load attempts

### DIFF
--- a/nodelet/src/loader.cpp
+++ b/nodelet/src/loader.cpp
@@ -280,9 +280,13 @@ bool Loader::load(const std::string &name, const std::string& type, const ros::M
       impl_->refresh_classes_();
       p = impl_->create_instance_(type);
     }
-    catch (std::runtime_error& e)
+    catch (std::runtime_error& e2)
     {
-      ROS_ERROR("Failed to load nodelet [%s] of type [%s]: %s", name.c_str(), type.c_str(), e.what());
+      // dlopen() can return inconsistent results currently (see
+      // https://sourceware.org/bugzilla/show_bug.cgi?id=17833), so make sure
+      // that we display the messages of both exceptions to the user.
+      ROS_ERROR("Failed to load nodelet [%s] of type [%s] even after refreshing the cache: %s", name.c_str(), type.c_str(), e2.what());
+      ROS_ERROR("The error before refreshing the cache was: %s", e.what());
       return false;
     }
   }


### PR DESCRIPTION
dlopen() can return inconsistent results currently (see https://sourceware.org/bugzilla/show_bug.cgi?id=17833), so make sure that we display the messages of both exceptions to the user.

Basically, the issue is that dlopen() can return 0 on the first load attempt, but cannot actually unload the library because of special symbols that become global. It silently leaves the half-initialized library in memory. The second call to dlopen() then returns a valid handle to that broken library! `nodelet` does not find any factories in there, though, so the user gets the message "no factory found", which is not helpful.

Without this PR:

```
[ERROR][/calibration_nodelet->Loader::load]: Failed to load nodelet [/Calibration] of type [openplatform/calibration]: MultiLibraryClassLoader: Could not create object of class type CalibrationNodelet as no factory exists for it. Make sure that the library exists and was explicitly loaded through MultiLibraryClassLoader::loadLibrary()
```

With this PR:

```
[ERROR][/calibration_nodelet->Loader::load]: Failed to load nodelet [/Calibration] of type [openplatform/calibration] even after refreshing the cache: MultiLibraryClassLoader: Could not create object of class type CalibrationNodelet as no factory exists for it. Make sure that the library exists and was explicitly loaded through MultiLibraryClassLoader::loadLibrary()
[ERROR][/calibration_nodelet->Loader::load]: The error before refreshing the cache was: Failed to load library /home/max/devel/uni/soccer/nimbro/devel/lib//libcalibration.so. Make sure that you are calling the PLUGINLIB_EXPORT_CLASS macro in the library code, and that names are consistent between this macro and your XML. Error string: Could not load library (Poco exception = /home/max/devel/uni/soccer/nimbro/devel/lib//libcalibration.so: undefined symbol: _ZN11ImageWidget16staticMetaObjectE)
```

The situation is certainly not nice, but I think providing all information to the user is the best we can do. Especially considering that hiding the first exception information has caused problems before (see #23)...
