### PR TITLE
[nodelet] Public api to check nodelet is initialized

### DIFF
--- a/nodelet/include/nodelet/nodelet.h
+++ b/nodelet/include/nodelet/nodelet.h
@@ -218,6 +218,9 @@ public:
   /**\brief Empty constructor required for dynamic loading */
   Nodelet();
 
+  /**\brief Whether the nodelet is initialized */
+  bool is_initialized();
+
   /**\brief Init function called at startup
    * \param name The name of the nodelet
    * \param remapping_args The remapping args in a map for the nodelet

--- a/nodelet/src/nodelet_class.cpp
+++ b/nodelet/src/nodelet_class.cpp
@@ -104,6 +104,11 @@ ros::NodeHandle& Nodelet::getMTPrivateNodeHandle() const
   return *mt_private_nh_;
 }
 
+bool Nodelet::is_initialized()
+{
+  return inited_;
+}
+
 void Nodelet::init(const std::string& name, const M_string& remapping_args, const V_string& my_argv,
                    ros::CallbackQueueInterface* st_queue, ros::CallbackQueueInterface* mt_queue)
 {
@@ -129,8 +134,8 @@ void Nodelet::init(const std::string& name, const M_string& remapping_args, cons
   mt_nh_->setCallbackQueue(mt_queue);
   
   NODELET_DEBUG ("Nodelet initializing");
-  inited_ = true;
   this->onInit ();
+  inited_ = true;
 }
 
 } // namespace nodelet


### PR DESCRIPTION
What I'd like to do is detecting the nodelet's initialization in the subclass of nodelet::Nodelet.
I mean after onInit() by 'initialization'.
