### PR TITLE
Install rules for test nodelet plugin xmls

### DIFF
--- a/test_nodelet/CMakeLists.txt
+++ b/test_nodelet/CMakeLists.txt
@@ -39,3 +39,6 @@ if(CATKIN_ENABLE_TESTING)
   add_executable(create_instance_cb_error src/create_instance_cb_error.cpp)
   target_link_libraries(create_instance_cb_error ${catkin_LIBRARIES})
 endif()
+
+# always install, since it is marked in the package.xml
+install(FILES test_nodelet.xml DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/test_nodelet_topic_tools/CMakeLists.txt
+++ b/test_nodelet_topic_tools/CMakeLists.txt
@@ -16,3 +16,6 @@ if(CATKIN_ENABLE_TESTING)
 
   add_rostest(test/test_nodelet_throttle.launch)
 endif()
+
+# always install, since it is marked in the package.xml
+install(FILES test/test_nodelets.xml DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/test)


### PR DESCRIPTION
Since they are always in package.xml, they should always get installed, otherwise
if they happened to be around in an installspace, then _any_ nodelet manager will
start barfing with "Skipping XML Document" errors (even if they are not loading
this particular nodelet).
