### PR TITLE
Add NodeletLazy abstract class for lazy transport

### DIFF
--- a/nodelet_topic_tools/include/nodelet_topic_tools/nodelet_lazy.h
+++ b/nodelet_topic_tools/include/nodelet_topic_tools/nodelet_lazy.h
@@ -199,8 +199,7 @@ protected:
   virtual void unsubscribe() = 0;
 
   /** @brief
-    * Advertise a topic and watch the publisher. Publishers which are
-    * created by this method.
+    * Update the list of Publishers created by this method.
     * It automatically reads latch boolean parameter from nh and
     * publish topic with appropriate latch parameter.
     *

--- a/nodelet_topic_tools/include/nodelet_topic_tools/nodelet_lazy.h
+++ b/nodelet_topic_tools/include/nodelet_topic_tools/nodelet_lazy.h
@@ -84,15 +84,13 @@ protected:
     ros::param::param<bool>("~use_multithread_callback", use_multithread, true);
     if (use_multithread)
     {
-      NODELET_DEBUG("[%s] [nodelet_topic_tools::NodeletLazy::onInit] use multithread callback",
-                    nodelet::Nodelet::getName().c_str());
+      NODELET_DEBUG("Using multithread callback");
       nh_.reset (new ros::NodeHandle(getMTNodeHandle()));
       pnh_.reset (new ros::NodeHandle(getMTPrivateNodeHandle()));
     }
     else
     {
-      NODELET_DEBUG("[%s] [nodelet_topic_tools::NodeletLazy::onInit] use singlethread callback",
-                    nodelet::Nodelet::getName().c_str());
+      NODELET_DEBUG("Using singlethread callback");
       nh_.reset(new ros::NodeHandle(getNodeHandle()));
       pnh_.reset(new ros::NodeHandle(getPrivateNodeHandle()));
     }
@@ -135,8 +133,7 @@ protected:
   {
     if (verbose_connection_)
     {
-      NODELET_INFO("[%s] [nodelet_topic_tools::NodeletLazy::connectionCallback] New connection or disconnection is detected",
-                   nodelet::Nodelet::getName().c_str());
+      NODELET_INFO("New connection or disconnection is detected");
     }
     if (lazy_)
     {
@@ -154,8 +151,7 @@ protected:
           {
             if (verbose_connection_)
             {
-              NODELET_INFO("[%s] [nodelet_topic_tools::NodeletLazy::connectionCallback] Subscribe input topics",
-                           nodelet::Nodelet::getName().c_str());
+              NODELET_INFO("Subscribe input topics");
             }
             subscribe();
             connection_status_ = SUBSCRIBED;
@@ -167,8 +163,7 @@ protected:
       {
         if (verbose_connection_)
         {
-          NODELET_INFO("[%s] [nodelet_topic_tools::NodeletLazy::connectionCallback] Unsubscribe input topics",
-                       nodelet::Nodelet::getName().c_str());
+          NODELET_INFO("Unsubscribe input topics");
         }
         unsubscribe();
         connection_status_ = NOT_SUBSCRIBED;
@@ -184,8 +179,7 @@ protected:
   {
     if (!ever_subscribed_)
     {
-      NODELET_WARN("[%s] [nodelet_topic_tools::NodeletLazy::warnNeverSubscribedCallback] this node/nodelet subscribes topics only when subscribed.",
-                   nodelet::Nodelet::getName().c_str());
+      NODELET_WARN("This node/nodelet subscribes topics only when subscribed.");
     }
   }
 

--- a/nodelet_topic_tools/include/nodelet_topic_tools/nodelet_lazy.h
+++ b/nodelet_topic_tools/include/nodelet_topic_tools/nodelet_lazy.h
@@ -1,0 +1,290 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014-2016, JSK Lab, University of Tokyo.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Ryohei Ueda, Kentaro Wada <www.kentaro.wada@gmail.com>
+ */
+
+#ifndef NODELET_LAZY_H_
+#define NODELET_LAZY_H_
+
+#include <ros/ros.h>
+#include <nodelet/nodelet.h>
+#include <boost/thread.hpp>
+#include <string>
+#include <vector>
+
+namespace nodelet_topic_tools
+{
+
+/** @brief
+  * Enum to represent connection status.
+  */
+enum ConnectionStatus
+{
+  NOT_INITIALIZED,
+  NOT_SUBSCRIBED,
+  SUBSCRIBED
+};
+
+/** @brief
+  * Nodelet to automatically subscribe/unsubscribe
+  * topics according to subscription of advertised topics.
+  *
+  * It's important not to subscribe topic if no output is required.
+  *
+  * In order to watch advertised topics, need to use advertise template method.
+  * And create subscribers in subscribe() and shutdown them in unsubscribed().
+  *
+  */
+class NodeletLazy: public nodelet::Nodelet
+{
+public:
+  NodeletLazy() {}
+
+protected:
+  /** @brief
+    * Initialize nodehandles nh_ and pnh_. Subclass should call
+    * this method in its onInit method
+    */
+  virtual void onInit()
+  {
+    connection_status_ = NOT_SUBSCRIBED;
+    bool use_multithread;
+    ros::param::param<bool>("~use_multithread_callback", use_multithread, true);
+    if (use_multithread)
+    {
+      NODELET_DEBUG("[%s] [nodelet_topic_tools::NodeletLazy::onInit] use multithread callback",
+                    nodelet::Nodelet::getName().c_str());
+      nh_.reset (new ros::NodeHandle(getMTNodeHandle()));
+      pnh_.reset (new ros::NodeHandle(getMTPrivateNodeHandle()));
+    }
+    else
+    {
+      NODELET_DEBUG("[%s] [nodelet_topic_tools::NodeletLazy::onInit] use singlethread callback",
+                    nodelet::Nodelet::getName().c_str());
+      nh_.reset(new ros::NodeHandle(getNodeHandle()));
+      pnh_.reset(new ros::NodeHandle(getPrivateNodeHandle()));
+    }
+    // option to use lazy transport
+    pnh_->param("lazy", lazy_, true);
+    // option for logging about being subscribed
+    pnh_->param("verbose_connection", verbose_connection_, false);
+    if (!verbose_connection_)
+    {
+      nh_->param("verbose_connection", verbose_connection_, false);
+    }
+    // timer to warn when no connection in a few seconds
+    ever_subscribed_ = false;
+    timer_ever_subscribed_ = nh_->createWallTimer(
+      ros::WallDuration(5),
+      &NodeletLazy::warnNeverSubscribedCallback,
+      this,
+      /*oneshot=*/true);
+  }
+
+  /** @brief
+    * Post processing of initialization of nodelet.
+    * You need to call this method in order to use always_subscribe
+    * feature.
+    */
+  virtual void onInitPostProcess()
+  {
+    if (!lazy_)
+    {
+      boost::mutex::scoped_lock lock(connection_mutex_);
+      ever_subscribed_ = true;
+      subscribe();
+    }
+  }
+
+  /** @brief
+    * callback function which is called when new subscriber come
+    */
+  virtual void connectionCallback(const ros::SingleSubscriberPublisher& pub)
+  {
+    if (verbose_connection_)
+    {
+      NODELET_INFO("[%s] [nodelet_topic_tools::NodeletLazy::connectionCallback] New connection or disconnection is detected",
+                   nodelet::Nodelet::getName().c_str());
+    }
+    if (lazy_)
+    {
+      boost::mutex::scoped_lock lock(connection_mutex_);
+      for (size_t i = 0; i < publishers_.size(); i++)
+      {
+        ros::Publisher pub = publishers_[i];
+        if (pub.getNumSubscribers() > 0)
+        {
+          if (!ever_subscribed_)
+          {
+            ever_subscribed_ = true;
+          }
+          if (connection_status_ != SUBSCRIBED)
+          {
+            if (verbose_connection_)
+            {
+              NODELET_INFO("[%s] [nodelet_topic_tools::NodeletLazy::connectionCallback] Subscribe input topics",
+                           nodelet::Nodelet::getName().c_str());
+            }
+            subscribe();
+            connection_status_ = SUBSCRIBED;
+          }
+          return;
+        }
+      }
+      if (connection_status_ == SUBSCRIBED)
+      {
+        if (verbose_connection_)
+        {
+          NODELET_INFO("[%s] [nodelet_topic_tools::NodeletLazy::connectionCallback] Unsubscribe input topics",
+                       nodelet::Nodelet::getName().c_str());
+        }
+        unsubscribe();
+        connection_status_ = NOT_SUBSCRIBED;
+      }
+    }
+  }
+
+  /** @brief
+    * callback function which is called when walltimer
+    * duration run out.
+    */
+  virtual void warnNeverSubscribedCallback(const ros::WallTimerEvent& event)
+  {
+    if (!ever_subscribed_)
+    {
+      NODELET_WARN("[%s] [nodelet_topic_tools::NodeletLazy::warnNeverSubscribedCallback] this node/nodelet subscribes topics only when subscribed.",
+                   nodelet::Nodelet::getName().c_str());
+    }
+  }
+
+
+  /** @brief
+    * This method is called when publisher is subscribed by other
+    * nodes.
+    * Set up subscribers in this method.
+    */
+  virtual void subscribe() = 0;
+
+  /** @brief
+    * This method is called when publisher is unsubscribed by other
+    * nodes.
+    * Shut down subscribers in this method.
+    */
+  virtual void unsubscribe() = 0;
+
+  /** @brief
+    * Advertise a topic and watch the publisher. Publishers which are
+    * created by this method.
+    * It automatically reads latch boolean parameter from nh and
+    * publish topic with appropriate latch parameter.
+    *
+    * @param nh NodeHandle.
+    * @param topic topic name to advertise.
+    * @param queue_size queue size for publisher.
+    * @param latch set true if latch topic publication.
+    * @return Publisher for the advertised topic.
+    */
+  template<class T> ros::Publisher
+  advertise(ros::NodeHandle& nh,
+            std::string topic, int queue_size, bool latch=false)
+  {
+    boost::mutex::scoped_lock lock(connection_mutex_);
+    ros::SubscriberStatusCallback connect_cb
+      = boost::bind(&NodeletLazy::connectionCallback, this, _1);
+    ros::SubscriberStatusCallback disconnect_cb
+      = boost::bind(&NodeletLazy::connectionCallback, this, _1);
+    ros::Publisher pub = nh.advertise<T>(topic, queue_size,
+                                          connect_cb,
+                                          disconnect_cb,
+                                          ros::VoidConstPtr(),
+                                          latch);
+    publishers_.push_back(pub);
+    return pub;
+  }
+
+  /** @brief
+    * mutex to call subscribe() and unsubscribe() in
+    * critical section.
+    */
+  boost::mutex connection_mutex_;
+
+  /** @brief
+    * Shared pointer to nodehandle.
+    */
+  boost::shared_ptr<ros::NodeHandle> nh_;
+
+  /** @brief
+    * Shared pointer to private nodehandle.
+    */
+  boost::shared_ptr<ros::NodeHandle> pnh_;
+
+  /** @brief
+    * List of watching publishers
+    */
+  std::vector<ros::Publisher> publishers_;
+
+  /** @brief
+    * WallTimer instance for warning about no connection.
+    */
+  ros::WallTimer timer_ever_subscribed_;
+
+  /** @brief
+    * A flag to check if the node has been ever subscribed
+    * or not.
+    */
+  bool ever_subscribed_;
+
+  /** @brief
+    * A flag to disable watching mechanism and always subscribe input
+    * topics. It can be specified via `~lazy` parameter.
+    */
+  bool lazy_;
+
+  /** @brief
+    * Status of connection
+    */
+  ConnectionStatus connection_status_;
+
+  /** @brief
+    * true if `~verbose_connection` or `verbose_connection` parameter is true.
+    */
+  bool verbose_connection_;
+
+private:
+};
+
+}  // namespace nodelet_topic_tools
+
+#endif  // NODELET_LAZY_H_

--- a/nodelet_topic_tools/include/nodelet_topic_tools/nodelet_lazy.h
+++ b/nodelet_topic_tools/include/nodelet_topic_tools/nodelet_lazy.h
@@ -102,13 +102,19 @@ protected:
     {
       nh_->param("verbose_connection", verbose_connection_, false);
     }
-    // timer to warn when no connection in a few seconds
+    // timer to warn when no connection in the specified seconds
     ever_subscribed_ = false;
-    timer_ever_subscribed_ = nh_->createWallTimer(
-      ros::WallDuration(5),
-      &NodeletLazy::warnNeverSubscribedCallback,
-      this,
-      /*oneshot=*/true);
+    double duration_to_warn_no_connection;
+    pnh_->param("duration_to_warn_no_connection",
+                duration_to_warn_no_connection, 5.0);
+    if (duration_to_warn_no_connection > 0)
+    {
+      timer_ever_subscribed_ = nh_->createWallTimer(
+        ros::WallDuration(duration_to_warn_no_connection),
+        &NodeletLazy::warnNeverSubscribedCallback,
+        this,
+        /*oneshot=*/true);
+    }
   }
 
   /** @brief

--- a/nodelet_topic_tools/include/nodelet_topic_tools/nodelet_lazy.h
+++ b/nodelet_topic_tools/include/nodelet_topic_tools/nodelet_lazy.h
@@ -121,8 +121,8 @@ protected:
     if (!lazy_)
     {
       boost::mutex::scoped_lock lock(connection_mutex_);
-      ever_subscribed_ = true;
       subscribe();
+      ever_subscribed_ = true;
     }
   }
 
@@ -143,10 +143,6 @@ protected:
         ros::Publisher pub = publishers_[i];
         if (pub.getNumSubscribers() > 0)
         {
-          if (!ever_subscribed_)
-          {
-            ever_subscribed_ = true;
-          }
           if (connection_status_ != SUBSCRIBED)
           {
             if (verbose_connection_)
@@ -155,6 +151,10 @@ protected:
             }
             subscribe();
             connection_status_ = SUBSCRIBED;
+          }
+          if (!ever_subscribed_)
+          {
+            ever_subscribed_ = true;
           }
           return;
         }

--- a/test_nodelet_topic_tools/CMakeLists.txt
+++ b/test_nodelet_topic_tools/CMakeLists.txt
@@ -10,9 +10,10 @@ catkin_package(
 
 if(CATKIN_ENABLE_TESTING)
   include_directories(SYSTEM ${catkin_INCLUDE_DIRS})
-  add_library(test_nodelet_topic_tools test/string_nodelet_throttle.cpp)
+  add_library(test_nodelet_topic_tools test/string_nodelet_lazy.cpp test/string_nodelet_throttle.cpp)
   target_link_libraries(test_nodelet_topic_tools ${catkin_LIBRARIES})
   add_dependencies(test_nodelet_topic_tools ${catkin_EXPORTED_TARGETS})
 
+  add_rostest(test/test_nodelet_lazy.launch)
   add_rostest(test/test_nodelet_throttle.launch)
 endif()

--- a/test_nodelet_topic_tools/test/empty_string_publisher.py
+++ b/test_nodelet_topic_tools/test/empty_string_publisher.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+###############################################################################
+# Software License Agreement (BSD License)
+#
+#  Copyright (c) 2016, JSK Lab, University of Tokyo.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the following
+#     disclaimer in the documentation and/o2r other materials provided
+#     with the distribution.
+#   * Neither the name of the JSK Lab nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+#  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+#  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+#  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+#  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+#  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+#  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+#  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+#  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+
+__author__ = 'Kentaro Wada <www.kentaro.wada@gmail.com>'
+
+import rospy
+from std_msgs.msg import String
+
+
+class EmptyStringPublisher(object):
+
+    def __init__(self):
+        self.pub = rospy.Publisher('~output', String, queue_size=1)
+        self.timer_pub = rospy.Timer(
+            rospy.Duration(0.1), self.publish_callback)
+
+    def publish_callback(self, event):
+        self.pub.publish(String())
+
+
+if __name__ == '__main__':
+    rospy.init_node('empty_string_publisher')
+    EmptyStringPublisher()
+    rospy.spin()

--- a/test_nodelet_topic_tools/test/string_nodelet_lazy.cpp
+++ b/test_nodelet_topic_tools/test/string_nodelet_lazy.cpp
@@ -1,0 +1,79 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2016, JSK Lab, University of Tokyo.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Kentaro Wada <www.kentaro.wada@gmail.com>
+ */
+
+#include <nodelet_topic_tools/nodelet_lazy.h>
+#include <std_msgs/String.h>
+
+namespace test_nodelet_topic_tools
+{
+
+class NodeletLazyString: public nodelet_topic_tools::NodeletLazy
+{
+public:
+protected:
+  virtual void onInit()
+  {
+    nodelet_topic_tools::NodeletLazy::onInit();
+    pub_ = advertise<std_msgs::String>(*pnh_, "output", 1);
+    onInitPostProcess();
+  }
+
+  virtual void subscribe()
+  {
+    sub_ = pnh_->subscribe("input", 1, &NodeletLazyString::callback, this);
+  }
+
+  virtual void unsubscribe()
+  {
+    sub_.shutdown();
+  }
+
+  virtual void callback(const std_msgs::String::ConstPtr& msg)
+  {
+    pub_.publish(msg);
+  }
+
+  ros::Publisher pub_;
+  ros::Subscriber sub_;
+
+private:
+};
+
+}  // namespace test_nodelet_topic_tools
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(test_nodelet_topic_tools::NodeletLazyString, nodelet::Nodelet);

--- a/test_nodelet_topic_tools/test/test_lazy.py
+++ b/test_nodelet_topic_tools/test/test_lazy.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+###############################################################################
+# Software License Agreement (BSD License)
+#
+#  Copyright (c) 2016, JSK Lab, University of Tokyo.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the following
+#     disclaimer in the documentation and/o2r other materials provided
+#     with the distribution.
+#   * Neither the name of the JSK Lab nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+#  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+#  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+#  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+#  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+#  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+#  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+#  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+#  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+
+__author__ = 'Kentaro Wada <www.kentaro.wada@gmail.com>'
+
+import os
+import sys
+
+import unittest
+
+import rosgraph
+import rospy
+import rosmsg
+import roslib
+
+
+PKG = 'test_nodelet_topic_tools'
+NAME = 'test_lazy'
+
+
+class TestConnection(unittest.TestCase):
+
+    def __init__(self, *args):
+        super(TestConnection, self).__init__(*args)
+        rospy.init_node(NAME)
+        self.master = rosgraph.Master(NAME)
+
+    def test_no_subscribers(self):
+        check_connected_topics = rospy.get_param('~check_connected_topics')
+        # Check assumed topics are not there
+        _, subscriptions, _ = self.master.getSystemState()
+        for check_topic in check_connected_topics:
+            for topic, sub_node in subscriptions:
+                if topic == rospy.get_namespace() + check_topic:
+                    raise ValueError('Found topic: {}'.format(check_topic))
+
+    def test_subscriber_appears(self):
+        topic_type = rospy.get_param('~input_topic_type')
+        check_connected_topics = rospy.get_param('~check_connected_topics')
+        wait_time = rospy.get_param('~wait_for_connection', 0)
+        msg_class = roslib.message.get_message_class(topic_type)
+        # Subscribe topic and bond connection
+        sub = rospy.Subscriber('~input', msg_class,
+                               self._cb_test_subscriber_appears)
+        print('Waiting for connection for {} sec.'.format(wait_time))
+        rospy.sleep(wait_time)
+        # Check assumed topics are there
+        _, subscriptions, _ = self.master.getSystemState()
+        for check_topic in check_connected_topics:
+            for topic, sub_node in subscriptions:
+                if topic == rospy.get_namespace() + check_topic:
+                    break
+            else:
+                raise ValueError('Not found topic: {}'.format(check_topic))
+
+    def _cb_test_subscriber_appears(self, msg):
+        pass
+
+
+if __name__ == "__main__":
+    import rostest
+    rostest.rosrun(PKG, NAME, TestConnection)

--- a/test_nodelet_topic_tools/test/test_nodelet_lazy.launch
+++ b/test_nodelet_topic_tools/test/test_nodelet_lazy.launch
@@ -1,0 +1,41 @@
+<launch>
+
+  <node name="empty_string_publisher"
+        pkg="test_nodelet_topic_tools" type="empty_string_publisher.py">
+    <remap from="~output" to="input" />
+  </node>
+
+  <param name="verbose_connection" value="true" />
+
+  <node name="string_nodelet_lazy_0"
+        pkg="nodelet" type="nodelet"
+        args="standalone test_nodelet_topic_tools/NodeletLazyString"
+        output="screen">
+    <remap from="~input"  to="input"/>
+  </node>
+  <node name="string_nodelet_lazy_1"
+        pkg="nodelet" type="nodelet"
+        args="standalone test_nodelet_topic_tools/NodeletLazyString"
+        output="screen">
+    <remap from="~input"  to="string_nodelet_lazy_0/output"/>
+  </node>
+  <node name="string_nodelet_lazy_2"
+        pkg="nodelet" type="nodelet"
+        args="standalone test_nodelet_topic_tools/NodeletLazyString"
+        output="screen">
+    <remap from="~input"  to="string_nodelet_lazy_1/output"/>
+  </node>
+
+  <test test-name="test_lazy"
+        name="test_lazy"
+        pkg="test_nodelet_topic_tools" type="test_lazy.py"
+        retry="3">
+    <rosparam>
+      input_topic_type: std_msgs/String
+      check_connected_topics: [string_nodelet_lazy_0/output, string_nodelet_lazy_1/output]
+      wait_for_connection: 3
+    </rosparam>
+    <remap from="~input" to="string_nodelet_lazy_2/output" />
+  </test>
+
+</launch>

--- a/test_nodelet_topic_tools/test/test_nodelets.xml
+++ b/test_nodelet_topic_tools/test/test_nodelets.xml
@@ -4,4 +4,9 @@
       Throttle strings in nodelet (testing only).
     </description>
   </class>
+  <class name="test_nodelet_topic_tools/NodeletLazyString" type="test_nodelet_topic_tools::NodeletLazyString" base_class_type="nodelet::Nodelet">
+    <description>
+      Lazy transport strings in nodelet (testing only).
+    </description>
+  </class>
 </library>


### PR DESCRIPTION
This class is to crete nodelet for 'lazy' transport.
Class for Python node is already merged in kinetic-devel branch of topic_tools.  https://github.com/ros/ros_comm/pull/713

Lazy transport is an essential feature for perception nodelets that handle image and point cloud, because
the processing should run only when it is necessary to reduce the CPU load.

FYI, the similar nodelet abstract class is used in ros-perception/opencv_apps package. https://github.com/ros-perception/opencv_apps/blob/indigo/include/opencv_apps/nodelet.h
