### PR TITLE
Fix bond handling during nodelet unloading

### DIFF
--- a/nodelet/src/nodelet.cpp
+++ b/nodelet/src/nodelet.cpp
@@ -331,9 +331,10 @@ int
     if (arg_parser.isBondEnabled())
       bond.start();
     // Spin our own loop
+    ros::AsyncSpinner spinner(1);
+    spinner.start();
     while (!request_shutdown)
     {
-      ros::spinOnce();
       if (arg_parser.isBondEnabled() && bond.isBroken())
       {
         ROS_INFO("Bond broken, exiting");

--- a/test_nodelet/CMakeLists.txt
+++ b/test_nodelet/CMakeLists.txt
@@ -30,6 +30,7 @@ if(CATKIN_ENABLE_TESTING)
 
   add_rostest(test/test_console.launch)
   add_rostest(test/test_bond_break_on_shutdown.launch)
+  add_rostest(test/test_unload_called_twice.launch)
 
   # Not a real test. Tries to measure overhead of CallbackQueueManager.
   add_executable(benchmark src/benchmark.cpp)

--- a/test_nodelet/CMakeLists.txt
+++ b/test_nodelet/CMakeLists.txt
@@ -29,6 +29,7 @@ if(CATKIN_ENABLE_TESTING)
   add_dependencies(tests test_console)
 
   add_rostest(test/test_console.launch)
+  add_rostest(test/test_bond_break_on_shutdown.launch)
 
   # Not a real test. Tries to measure overhead of CallbackQueueManager.
   add_executable(benchmark src/benchmark.cpp)

--- a/test_nodelet/debug_logging.conf
+++ b/test_nodelet/debug_logging.conf
@@ -1,0 +1,1 @@
+log4j.logger.ros=DEBUG

--- a/test_nodelet/test/test_bond_break_on_shutdown.launch
+++ b/test_nodelet/test/test_bond_break_on_shutdown.launch
@@ -1,0 +1,4 @@
+<launch>
+  <env name="ROSCONSOLE_CONFIG_FILE" value="$(find test_nodelet)/debug_logging.conf"/>
+  <test test-name="test_bond_break_on_shutdown" pkg="test_nodelet" type="test_bond_break_on_shutdown.py" />
+</launch>

--- a/test_nodelet/test/test_bond_break_on_shutdown.py
+++ b/test_nodelet/test/test_bond_break_on_shutdown.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+
+import roslib; roslib.load_manifest('test_nodelet')
+import rospy
+import unittest
+import rostest
+import signal
+import subprocess
+import time
+
+from nodelet.srv import *
+
+class TestBondBreakOnShutdown(unittest.TestCase):
+    def test_bond_break_on_shutdown(self):
+        '''
+        Test that the bond is broken cleanly when closing a nodelet loader (#50).
+        This relies on a debug message printed by the bondcpp package in case
+        of error.
+        '''
+
+        # start nodelet manager
+        proc_manager = subprocess.Popen(["rosrun", "nodelet", "nodelet", "manager", "__name:=nodelet_manager"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            bufsize=-1
+        )
+
+        # wait for nodelet manager to be ready
+        try:
+            rospy.wait_for_service('/nodelet_manager/load_nodelet', timeout=2)
+        except:
+            self.fail("Could not determine that nodelet manager has started")
+
+        # load a nodelet
+        proc_nodelet = subprocess.Popen(["rosrun", "nodelet", "nodelet", "load", "test_nodelet/Plus", "nodelet_manager", "__name:=test"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            bufsize=-1
+        )
+
+        # wait for it to be ready
+        try:
+            rospy.wait_for_service('test/get_loggers', timeout=2)
+        except:
+            self.fail("Could not determine that nodelet has started")
+        time.sleep(1)
+
+        # stop the nodelet loader via signal (similar to roslaunch killing it)
+        proc_nodelet.send_signal(signal.SIGINT)
+        (n_out, n_err) = proc_nodelet.communicate()
+
+        # stop the nodelet manager, too
+        proc_manager.send_signal(signal.SIGINT)
+        (m_out, m_err) = proc_manager.communicate()
+
+        # check that nodelet unloaded and there was no error with bond breaking
+        self.assertIn('Unloading nodelet /test from manager nodelet_manager', n_out)
+        self.assertNotIn('Bond failed to break on destruction', m_out)
+        self.assertNotIn('Bond failed to break on destruction', n_out)
+
+if __name__ == '__main__':
+    rospy.init_node('test_bond_break_on_shutdown')
+    rostest.unitrun('test_bond_break_on_shutdown', 'test_bond_break_on_shutdown', TestBondBreakOnShutdown)
+

--- a/test_nodelet/test/test_unload_called_twice.launch
+++ b/test_nodelet/test/test_unload_called_twice.launch
@@ -1,0 +1,3 @@
+<launch>
+  <test test-name="unload_called_twice" pkg="test_nodelet" type="test_unload_called_twice.py" />
+</launch>

--- a/test_nodelet/test/test_unload_called_twice.py
+++ b/test_nodelet/test/test_unload_called_twice.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+import roslib; roslib.load_manifest('test_nodelet')
+import rospy
+import unittest
+import rostest
+import signal
+import subprocess
+import time
+
+from nodelet.srv import *
+
+class TestUnloadCalledTwice(unittest.TestCase):
+    def test_unload_called_twice(self):
+        '''
+        Test that when a nodelet loader is stopped and requests unloading,
+        the unload() call in LoaderROS is not run twice (#50).
+        '''
+
+        # start nodelet manager
+        proc_manager = subprocess.Popen(["rosrun", "nodelet", "nodelet", "manager", "__name:=nodelet_manager"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            bufsize=-1
+        )
+
+        # wait for nodelet manager to be ready
+        try:
+            rospy.wait_for_service('/nodelet_manager/load_nodelet', timeout=2)
+        except:
+            self.fail("Could not determine that nodelet manager has started")
+
+        # load nodelet
+        proc_nodelet = subprocess.Popen(["rosrun", "nodelet", "nodelet", "load", "test_nodelet/Plus", "nodelet_manager", "__name:=test"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+        )
+
+        # wait for nodelet to be ready
+        try:
+            rospy.wait_for_service('test/get_loggers', timeout=2)
+        except:
+            self.fail("Could not determine that nodelet has started")
+        time.sleep(1)
+
+        # stop the nodelet loader via signal (similar to roslaunch killing it)
+        proc_nodelet.send_signal(signal.SIGINT)
+        (n_out, n_err) = proc_nodelet.communicate()
+
+        # stop the nodelet manager, too
+        proc_manager.send_signal(signal.SIGINT)
+        (m_out, m_err) = proc_manager.communicate()
+
+        # check that nodelet unloaded and that LoaderROS::unload() does not
+        # complain about nodelet not being found (an indication that it was called
+        # again after the nodelet was already unloaded)
+        self.assertIn('Unloading nodelet /test from manager nodelet_manager', n_out)
+        self.assertNotIn('Failed to find nodelet with name', m_err)
+
+if __name__ == '__main__':
+    rospy.init_node('test_unload_called_twice')
+    rostest.unitrun('test_unload_called_twice', 'test_unload_called_twice', TestUnloadCalledTwice)


### PR DESCRIPTION
This fixes points 2 and 3 of #50 and introduces two changes:
1. The callback for broken bonds is reset when unloading, to avoid calling `unload()` again.
2. `nodelet load` uses an ASyncSpinner in order to handle bond communication during shutdown.
