### PR TITLE
Show pkg and manifest file with verbose option

### DIFF
--- a/nodelet/scripts/declared_nodelets
+++ b/nodelet/scripts/declared_nodelets
@@ -71,8 +71,9 @@ def main():
                 for lib in dom.getElementsByTagName('library'):
                     for name in lib.getElementsByTagName('class'):
                         nodelets.append(name.getAttribute('name'))
-            except xml.parsers.expat.ExpatError:
-                pass
+            except xml.parsers.expat.ExpatError as e:
+                print('%s: %s' % (f, e), file=sys.stderr)
+                continue
         declared_nodelets.append({
             'package': p,
             'manifest': f,

--- a/nodelet/scripts/declared_nodelets
+++ b/nodelet/scripts/declared_nodelets
@@ -35,7 +35,6 @@
 from __future__ import print_function
 
 import argparse
-import collections
 import sys
 
 import rospkg

--- a/nodelet/scripts/declared_nodelets
+++ b/nodelet/scripts/declared_nodelets
@@ -46,6 +46,7 @@ import xml
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('-v', '--verbose', action='store_true')
+    parser.add_argument('-p', '--package')
     args = parser.parse_args()
 
     rp = rospkg.RosPack()
@@ -80,6 +81,8 @@ def main():
         })
 
     for declared in declared_nodelets:
+        if args.package and declared['package'] != args.package:
+            continue
         if args.verbose:
             print('- package: %s' % declared['package'])
             print('  manifest: %s' % declared['manifest'])

--- a/nodelet/scripts/declared_nodelets
+++ b/nodelet/scripts/declared_nodelets
@@ -36,10 +36,10 @@ from __future__ import print_function
 
 import argparse
 import sys
+import xml
+from xml.dom import minidom
 
 import rospkg
-from xml.dom import minidom
-import xml
 
 
 def main():

--- a/nodelet/scripts/declared_nodelets
+++ b/nodelet/scripts/declared_nodelets
@@ -32,40 +32,64 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import print_function
 
+import argparse
+import collections
+import sys
 
 import rospkg
 from xml.dom import minidom
 import xml
 
-nodelet_files = []
 
-rp = rospkg.RosPack()
-for p in rp.get_depends_on('nodelet', implicit=False):
-    #print "Processing package %s to find declared nodelets"%p
-    manifest = rp.get_manifest(p)
-    for e in manifest.exports:
-        try:
-            if e.__dict__['tag'] == 'nodelet':
-                plugin_file = e.get('plugin')
-                if plugin_file:
-                    plugin_file = plugin_file.replace('${prefix}', rp.get_path(p))
-                    nodelet_files.append(plugin_file)
-        except Exception, ex:
-            print ex 
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-v', '--verbose', action='store_true')
+    args = parser.parse_args()
 
-declared_nodelets = []
+    rp = rospkg.RosPack()
+    nodelet_files = []
+    for p in rp.get_depends_on('nodelet', implicit=False):
+        manifest = rp.get_manifest(p)
+        for e in manifest.exports:
+            try:
+                if e.__dict__['tag'] == 'nodelet':
+                    plugin_file = e.get('plugin')
+                    if plugin_file:
+                        plugin_file = plugin_file.replace('${prefix}', rp.get_path(p))
+                        nodelet_files.append((p, plugin_file))
+            except Exception as e:
+                print(e, file=sys.stderr)
 
-for f in nodelet_files:
-    with open(f) as fh:
-        try:
-            dom = minidom.parse(fh)
-            for lib in dom.getElementsByTagName('library'):
-                for name in lib.getElementsByTagName('class'):
-                    declared_nodelets.append(name.getAttribute('name'))
-        except xml.parsers.expat.ExpatError, ex:
-            "failed to parse file %s"%f
+    declared_nodelets = []
+    for p, f in nodelet_files:
+        nodelets = []
+        with open(f) as fh:
+            try:
+                dom = minidom.parse(fh)
+                for lib in dom.getElementsByTagName('library'):
+                    for name in lib.getElementsByTagName('class'):
+                        nodelets.append(name.getAttribute('name'))
+            except xml.parsers.expat.ExpatError:
+                pass
+        declared_nodelets.append({
+            'package': p,
+            'manifest': f,
+            'nodelets': nodelets,
+        })
 
-#print "\n\nDECLARED NODELETS\n================="
-for n in declared_nodelets:
-    print n
+    for declared in declared_nodelets:
+        if args.verbose:
+            print('- package: %s' % declared['package'])
+            print('  manifest: %s' % declared['manifest'])
+            print('  nodelets:')
+            for nodelet in declared['nodelets']:
+                print('    - %s' % nodelet)
+        else:
+            for nodelet in declared['nodelets']:
+                print(nodelet)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- scripts/declared_nodelets

```
% rosrun nodelet declared_nodelets --verbose  # show in yaml format
- package: test_nodelet_topic_tools
  manifest: /home/wkentaro/Projects/jsk/src/ros/nodelet_core/test_nodelet_topic_tools/test/test_nodelets.xml
  nodelets:
    - test_nodelet_topic_tools/NodeletThrottleString
    - test_nodelet_topic_tools/NodeletLazyString
- package: jsk_topic_tools
  manifest: /opt/ros/indigo/share/jsk_topic_tools/jsk_topic_tools_nodelet.xml
  nodelets:
    - jsk_topic_tools/Snapshot
    - jsk_topic_tools/VitalCheckerNodelet
    - jsk_topic_tools/HzMeasure
    - jsk_topic_tools/LightweightThrottle
    - jsk_topic_tools/MUX
    - jsk_topic_tools/Relay
    - jsk_topic_tools/DeprecatedRelay
    - jsk_topic_tools/Passthrough
    - jsk_topic_tools/Block
    - jsk_topic_tools/StringRelay
- package: jsk_topic_tools
  manifest: /opt/ros/indigo/share/jsk_topic_tools/jsk_topic_tools_test_nodelet.xml
  nodelets:
    - jsk_topic_tools_test/LogUtils
...
```

```
% rosrun nodelet declared_nodelets --verbose --package test_nodelet
- package: test_nodelet
  manifest: /home/wkentaro/Projects/jsk/src/ros/nodelet_core/test_nodelet/test_nodelet.xml
  nodelets:
    - test_nodelet/Plus
    - test_nodelet/ConsoleTest
    - test_nodelet/FailingNodelet
```