### PR TITLE
Add getRemappingArgs method to nodelet to reuse it in subclass

### DIFF
--- a/nodelet/include/nodelet/nodelet.h
+++ b/nodelet/include/nodelet/nodelet.h
@@ -188,6 +188,7 @@ protected:
     return nodelet_name_ + "." + suffix;
   }
   inline const V_string& getMyArgv() const { return my_argv_; }
+  inline const M_string& getRemappingArgs() const { return remapping_args_; }
 
   ros::NodeHandle& getNodeHandle() const;
   ros::NodeHandle& getPrivateNodeHandle() const;
@@ -209,6 +210,7 @@ private:
   NodeHandlePtr mt_nh_;
   NodeHandlePtr mt_private_nh_;
   V_string my_argv_;
+  M_string remapping_args_;
 
   // Method to be overridden by subclass when starting up.
   virtual void onInit() = 0;

--- a/nodelet/src/nodelet_class.cpp
+++ b/nodelet/src/nodelet_class.cpp
@@ -113,8 +113,8 @@ void Nodelet::init(const std::string& name, const M_string& remapping_args, cons
   }
 
   nodelet_name_ = name;
-  my_argv_ = my_argv;
   remapping_args_ = remapping_args;
+  my_argv_ = my_argv;
 
   // Set up NodeHandles with correct namespaces
   private_nh_.reset(new ros::NodeHandle(name, remapping_args));

--- a/nodelet/src/nodelet_class.cpp
+++ b/nodelet/src/nodelet_class.cpp
@@ -114,6 +114,7 @@ void Nodelet::init(const std::string& name, const M_string& remapping_args, cons
 
   nodelet_name_ = name;
   my_argv_ = my_argv;
+  remapping_args_ = remapping_args;
 
   // Set up NodeHandles with correct namespaces
   private_nh_.reset(new ros::NodeHandle(name, remapping_args));


### PR DESCRIPTION
Why?

I'd like to add feature of checking topics which must be remapped.
This kind of checking is also conducted in image_view and seems common,
https://github.com/ros-perception/image_pipeline/blob/indigo/image_view/src/nodes/image_view.cpp#L143
however, in nodelet subclass it is not possible to get the remapping args passed as command line arguments
by ros::names::getRemappings().

For actual usecase, please refer below PRs:

- https://github.com/jsk-ros-pkg/jsk_common/pull/1538/files (subclass of nodelet::Nodelet)
- https://github.com/jsk-ros-pkg/jsk_recognition/pull/2137/files (subsubclass of nodelet:Nodelet)