### PR TITLE
fix exec_depend that are actually build_export_depends

### DIFF
--- a/nodelet_topic_tools/package.xml
+++ b/nodelet_topic_tools/package.xml
@@ -20,8 +20,8 @@
   <depend>boost</depend>
   <depend>dynamic_reconfigure</depend>
 
-  <exec_depend>message_filters</exec_depend>
-  <exec_depend>nodelet</exec_depend>
-  <exec_depend>pluginlib</exec_depend>
-  <exec_depend>roscpp</exec_depend>
+  <build_export_depend>message_filters</build_export_depend>
+  <build_export_depend>nodelet</build_export_depend>
+  <build_export_depend>pluginlib</build_export_depend>
+  <build_export_depend>roscpp</build_export_depend>
 </package>


### PR DESCRIPTION
follow-up of https://github.com/ros/nodelet_core/pull/63