### PR TITLE
make onInit() behave sequential

### DIFF
--- a/nodelet/CHANGELOG.rst
+++ b/nodelet/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package nodelet
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* delay processing of queues until Nodelet::onInit() returns
+
 1.9.16 (2018-04-27)
 -------------------
 * uuid dependency fixup (`#74 <https://github.com/ros/nodelet_core/issues/74>`_)

--- a/nodelet/include/nodelet/detail/callback_queue.h
+++ b/nodelet/include/nodelet/detail/callback_queue.h
@@ -60,6 +60,16 @@ public:
 
   uint32_t callOne();
 
+  /**
+   * \brief Enable the queue (queue is enabled by default)
+   */
+  void enable();
+  /**
+   * \brief Disable the queue, meaning any calls to addCallback() will have no effect
+   */
+  void disable();
+
+
 private:
   CallbackQueueManager* parent_;
   ros::CallbackQueue queue_;

--- a/nodelet/include/nodelet/nodelet.h
+++ b/nodelet/include/nodelet/nodelet.h
@@ -162,6 +162,10 @@ typedef boost::shared_ptr<ros::NodeHandle> NodeHandlePtr;
 typedef std::map<std::string, std::string> M_string;
 typedef std::vector<std::string> V_string;
 
+namespace detail {
+	class CallbackQueue;
+}
+
 class UninitializedException : public Exception
 {
 public:

--- a/nodelet/src/callback_queue.cpp
+++ b/nodelet/src/callback_queue.cpp
@@ -78,5 +78,16 @@ uint32_t CallbackQueue::callOne()
   return queue_.callOne();
 }
 
+void CallbackQueue::enable()
+{
+  queue_.enable();
+}
+
+void CallbackQueue::disable()
+{
+  queue_.disable();
+}
+
+
 } // namespace detail
 } // namespace nodelet

--- a/nodelet/src/loader.cpp
+++ b/nodelet/src/loader.cpp
@@ -312,8 +312,14 @@ bool Loader::load(const std::string &name, const std::string& type, const ros::M
   ManagedNodelet* mn = new ManagedNodelet(p, impl_->callback_manager_.get());
   impl_->nodelets_.insert(const_cast<std::string&>(name), mn); // mn now owned by boost::ptr_map
   try {
+	mn->st_queue->disable();
+	mn->mt_queue->disable();
+
     p->init(name, remappings, my_argv, mn->st_queue.get(), mn->mt_queue.get());
-    /// @todo Can we delay processing the queues until Nodelet::onInit() returns?
+
+	mn->st_queue->enable();
+	mn->mt_queue->enable();
+
 
     ROS_DEBUG("Done initing nodelet %s", name.c_str());
   } catch(...) {


### PR DESCRIPTION
This patch will delay the processing of callback queues until
Nodelet::onInit successfully returned. This will avoid race conditions
with code in onInit() and callbacks that are being called while onInit()
is being executed. It also allows to do some blocking behavior inside
of onInit() the same way we do it in a traditional node before calling
`spin()` or `while(ros::ok()) {...}`.