### PR TITLE
Drop unneeded forward declaration.

### DIFF
--- a/nodelet/include/nodelet/detail/callback_queue_manager.h
+++ b/nodelet/include/nodelet/detail/callback_queue_manager.h
@@ -84,7 +84,6 @@ private:
   struct ThreadInfo;
   void workerThread(ThreadInfo*);
 
-  class ThreadInfo;
   ThreadInfo* getSmallestQueue();
 
   struct QueueInfo


### PR DESCRIPTION
It's already forward-declared correctly as a struct two lines up. Closes #67.