### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/test_nodelet/src/console_tests.cpp
+++ b/test_nodelet/src/console_tests.cpp
@@ -184,5 +184,5 @@ private:
 
 };
 
-PLUGINLIB_DECLARE_CLASS(test_nodelet, ConsoleTest, test_nodelet::ConsoleTest, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(test_nodelet::ConsoleTest, nodelet::Nodelet)
 }

--- a/test_nodelet/src/failing_nodelet.cpp
+++ b/test_nodelet/src/failing_nodelet.cpp
@@ -47,5 +47,5 @@ private:
   }
 };
 
-PLUGINLIB_DECLARE_CLASS(test_nodelet, FailingNodelet, test_nodelet::FailingNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(test_nodelet::FailingNodelet, nodelet::Nodelet)
 }

--- a/test_nodelet/src/plus.cpp
+++ b/test_nodelet/src/plus.cpp
@@ -68,5 +68,5 @@ private:
   double value_;
 };
 
-PLUGINLIB_DECLARE_CLASS(test_nodelet, Plus, test_nodelet::Plus, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(test_nodelet::Plus, nodelet::Nodelet)
 }

--- a/test_nodelet_topic_tools/test/string_nodelet_throttle.cpp
+++ b/test_nodelet_topic_tools/test/string_nodelet_throttle.cpp
@@ -7,4 +7,4 @@ namespace test_nodelet_topic_tools {
 typedef nodelet_topic_tools::NodeletThrottle<std_msgs::String> NodeletThrottleString;
 
 }
-PLUGINLIB_DECLARE_CLASS (test_nodelet_topic_tools, NodeletThrottleString, test_nodelet_topic_tools::NodeletThrottleString, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(test_nodelet_topic_tools::NodeletThrottleString, nodelet::Nodelet)


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions