### PR TITLE
nodelet: declared_nodelets: continue on missing plugin xml

### DIFF
--- a/nodelet/scripts/declared_nodelets
+++ b/nodelet/scripts/declared_nodelets
@@ -35,6 +35,7 @@
 from __future__ import print_function
 
 import argparse
+import os
 import sys
 import xml
 from xml.dom import minidom
@@ -65,6 +66,9 @@ def main():
     declared_nodelets = []
     for p, f in nodelet_files:
         nodelets = []
+        if not os.path.exists(f):
+            print('%s: %s' % (f, "The file does not exist."), file=sys.stderr)
+            continue
         with open(f) as fh:
             try:
                 dom = minidom.parse(fh)

--- a/nodelet/scripts/declared_nodelets
+++ b/nodelet/scripts/declared_nodelets
@@ -66,8 +66,8 @@ def main():
     declared_nodelets = []
     for p, f in nodelet_files:
         nodelets = []
-        if not os.path.exists(f):
-            print('%s: %s' % (f, "The file does not exist."), file=sys.stderr)
+        if not os.path.isfile(f):
+            print('%s: %s' % (f, 'The file does not exist.'), file=sys.stderr)
             continue
         with open(f) as fh:
             try:


### PR DESCRIPTION
`rosrun nodelet declared_nodelets` fails if there is a missing plugin xml on entire workspace.
This is for making loading continuing rather than just failure and print error message instead.