### PR TITLE
Bump CMake version to avoid CMP0048 warning

### DIFF
--- a/nodelet/CMakeLists.txt
+++ b/nodelet/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(nodelet)
 
 ## Find catkin dependencies

--- a/nodelet_core/CMakeLists.txt
+++ b/nodelet_core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(nodelet_core)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/nodelet_topic_tools/CMakeLists.txt
+++ b/nodelet_topic_tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(nodelet_topic_tools)
 
 find_package(catkin REQUIRED COMPONENTS dynamic_reconfigure)

--- a/test_nodelet/CMakeLists.txt
+++ b/test_nodelet/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(test_nodelet)
 

--- a/test_nodelet_topic_tools/CMakeLists.txt
+++ b/test_nodelet_topic_tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(test_nodelet_topic_tools)
 


### PR DESCRIPTION
This bumps the minimum CMake version to 3.0.2, which is the [minimum supported by ROS Kinetic](https://www.ros.org/reps/rep-0003.html#kinetic-kame-may-2016-may-2021) and new enough to default to the NEW behavior of [CMP0048](https://cmake.org/cmake/help/v3.0/policy/CMP0048.html). This avoids a CMake warning when building and testing this package in Debian Buster and Ubuntu Focal.


ros/catkin#1052