### PR TITLE
add version.h for nodelet

### DIFF
--- a/nodelet/CMakeLists.txt
+++ b/nodelet/CMakeLists.txt
@@ -12,6 +12,19 @@ find_package(catkin REQUIRED
   std_msgs
 )
 
+catkin_package_xml()
+# split version in parts and pass to extra file
+string(REPLACE "." ";" nodelet_VERSION_LIST "${nodelet_VERSION}")
+list(LENGTH nodelet_VERSION_LIST _count)
+if(NOT _count EQUAL 3)
+  message(FATAL_ERROR "nodelet version '${nodelet_VERSION}' does not match 'MAJOR.MINOR.PATCH' pattern")
+endif()
+list(GET nodelet_VERSION_LIST 0 nodelet_VERSION_MAJOR)
+list(GET nodelet_VERSION_LIST 1 nodelet_VERSION_MINOR)
+list(GET nodelet_VERSION_LIST 2 nodelet_VERSION_PATCH)
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/nodelet/version.h.in ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION}/nodelet/version.h)
+
 ## Find Boost (only headers)
 find_package(Boost REQUIRED)
 

--- a/nodelet/include/nodelet/version.h.in
+++ b/nodelet/include/nodelet/version.h.in
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2010, Willow Garage, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the names of Stanford University or Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NODELET_VERSION_
+#define NODELET_VERSION_
+
+#define NODELET_VERSION_MAJOR @nodelet_VERSION_MAJOR@
+#define NODELET_VERSION_MINOR @nodelet_VERSION_MINOR@
+#define NODELET_VERSION_PATCH @nodelet_VERSION_PATCH@
+#define NODELET_VERSION_COMBINED(major, minor, patch) (((major) << 20) | ((minor) << 10) | (patch))
+#define NODELET_VERSION NODELET_VERSION_COMBINED(NODELET_VERSION_MAJOR, NODELET_VERSION_MINOR, NODELET_VERSION_PATCH)
+
+#define NODELET_VERSION_GE(major1, minor1, patch1, major2, minor2, patch2) (NODELET_VERSION_COMBINED(major1, minor1, patch1) >= NODELET_VERSION_COMBINED(major2, minor2, patch2))
+#define NODELET_VERSION_MINIMUM(major, minor, patch) NODELET_VERSION_GE(NODELET_VERSION_MAJOR, NODELET_VERSION_MINOR, NODELET_VERSION_PATCH, major, minor, patch)
+
+#endif


### PR DESCRIPTION
I add `version.h` for `nodelet` to check `nodelet` version for build.
I made this PR as `roscpp`.
https://github.com/ros/ros_comm/blob/noetic-devel/clients/roscpp/CMakeLists.txt#L12-L23

I add `NODELET_VERSION_MAJOR`, `NODELET_VERSION_MINOR`, `NODELET_VERSION_PATCH` as `roscpp`.
I also add `NODELET_VERSION_MINIMUM` to check minimum nodelet version as `roscpp`