### PR TITLE
Fix callback queue breaking during slightly longer onInit() execution

### DIFF
--- a/nodelet/src/loader.cpp
+++ b/nodelet/src/loader.cpp
@@ -312,14 +312,8 @@ bool Loader::load(const std::string &name, const std::string& type, const ros::M
   ManagedNodelet* mn = new ManagedNodelet(p, impl_->callback_manager_.get());
   impl_->nodelets_.insert(const_cast<std::string&>(name), mn); // mn now owned by boost::ptr_map
   try {
-	mn->st_queue->disable();
-	mn->mt_queue->disable();
 
     p->init(name, remappings, my_argv, mn->st_queue.get(), mn->mt_queue.get());
-
-	mn->st_queue->enable();
-	mn->mt_queue->enable();
-
 
     ROS_DEBUG("Done initing nodelet %s", name.c_str());
   } catch(...) {


### PR DESCRIPTION
As described in https://github.com/ros/nodelet_core/issues/106, the current state of stopping the callback queue before onInit() can break callbacks for subscribers and timers for good.

I know this fix breaks the new intended behavior that callbacks won't be called while onInit() is still being executed. However, I will gladly check that in my callbacks (as it was needed until Noetic) in exchange for working callbacks. It took me a long time to debug why most of our [software](https://github.com/ctu-mrs/mrs_uav_system) just straight up did not work on Noetic. Or, I hope that maybe somebody will notice this PR and fix that issue properly.