### PR TITLE
Reduce boost dependency scope

### DIFF
--- a/nodelet/package.xml
+++ b/nodelet/package.xml
@@ -25,15 +25,17 @@
 
   <build_depend version_gte="0.3.2">cmake_modules</build_depend>
   <build_depend>message_generation</build_depend>
+  <build_depend>libboost-dev</build_depend>
+  <build_depend>libboost-thread-dev</build_depend>
 
   <depend>bondcpp</depend>
-  <depend>boost</depend>
   <depend version_gte="1.10.0">pluginlib</depend>
   <depend>rosconsole</depend>
   <depend>roscpp</depend>
   <depend>std_msgs</depend>
   <depend>uuid</depend>
 
+  <exec_depend>libboost-thread</exec_depend>
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>rospy</exec_depend>
 </package>

--- a/nodelet_topic_tools/package.xml
+++ b/nodelet_topic_tools/package.xml
@@ -16,10 +16,13 @@
   <author>Tully Foote</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>liboost-dev</build_depend>
+  <build_depend>liboost-thread-dev</build_depend>
 
-  <depend>boost</depend>
   <depend>dynamic_reconfigure</depend>
 
+  <build_export_depend>liboost-dev</build_export_depend>
+  <build_export_depend>liboost-thread-dev</build_export_depend>
   <build_export_depend>message_filters</build_export_depend>
   <build_export_depend>nodelet</build_export_depend>
   <build_export_depend>pluginlib</build_export_depend>

--- a/nodelet_topic_tools/package.xml
+++ b/nodelet_topic_tools/package.xml
@@ -16,13 +16,13 @@
   <author>Tully Foote</author>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>liboost-dev</build_depend>
-  <build_depend>liboost-thread-dev</build_depend>
+  <build_depend>libboost-dev</build_depend>
+  <build_depend>libboost-thread-dev</build_depend>
 
   <depend>dynamic_reconfigure</depend>
 
-  <build_export_depend>liboost-dev</build_export_depend>
-  <build_export_depend>liboost-thread-dev</build_export_depend>
+  <build_export_depend>libboost-dev</build_export_depend>
+  <build_export_depend>libboost-thread-dev</build_export_depend>
   <build_export_depend>message_filters</build_export_depend>
   <build_export_depend>nodelet</build_export_depend>
   <build_export_depend>pluginlib</build_export_depend>


### PR DESCRIPTION
`<depend>boost</depend>` resolves to `libboost-all-dev` on Ubuntu which is far too much for what is really needed. The `-dev` packages should never be needed at runtime. Instead, the corresponding libboost* (without -dev) libraries should be used as run_depend/exec_depend. Many boost libraries are also header only and don't need a runtime dependency either.

This PR should reduce the scope of boost dependencies quite a bit.