### PR TITLE
fix the issue when we have multiple top level tags i.e. library

### DIFF
--- a/nodelet/scripts/declared_nodelets
+++ b/nodelet/scripts/declared_nodelets
@@ -71,7 +71,8 @@ def main():
             continue
         with open(f) as fh:
             try:
-                dom = minidom.parse(fh)
+                xml_content = '<root>' + fh.read() + '</root>'
+                dom = minidom.parseString(xml_content)
                 for lib in dom.getElementsByTagName('library'):
                     for name in lib.getElementsByTagName('class'):
                         nodelets.append(name.getAttribute('name'))


### PR DESCRIPTION
# Handle multiple top-level tags in XML nodelet files

This pull request addresses a [bug](https://github.com/cra-ros-pkg/robot_localization/issues/519) found when parsing XML nodelet files that contain multiple top-level tags, which is not allowed in XML documents. The bug results in an ExpatError being raised by the xml.dom.minidom module.

In the proposed changes, we handle this scenario by reading the entire XML file into a string and manually adding a single root tag around it before parsing. This ensures that the resulting XML content always has exactly one root element, thus preventing the ExpatError.

By making this change, the script can now successfully parse XML nodelet files with multiple top-level tags, which improves its robustness and usability.