### PR TITLE
Do not subscribe /clock from `nodelet load`

### DIFF
--- a/nodelet/src/nodelet.cpp
+++ b/nodelet/src/nodelet.cpp
@@ -337,7 +337,8 @@ int
   }
   else if (command == "load")
   {
-    ros::init (argc, argv, arg_parser.getDefaultName (), ros::init_options::NoSigintHandler);
+    // NoSimTime option reduces CPU load when running with Gazebo with a fast clock topic.
+    ros::init (argc, argv, arg_parser.getDefaultName (), ros::init_options::NoSigintHandler | ros::init_options::NoSimTime);
     NodeletInterface ni;
     ros::NodeHandle nh;
     std::string name = ros::this_node::getName ();


### PR DESCRIPTION
Depends on https://github.com/ros/ros_comm/pull/2342 .

See discussion in https://robotics.stackexchange.com/questions/96165/nodelet-load-process-does-message-deserialization .

When running in `nodelet load` mode, the node doesn't really do anything that would require sim time. It should only run the bond, one service call and nothing else. This PR makes sure that it is the case even if `/use_sim_time` is set to true.