### PR TITLE
Fix use-after-free when a nodelet throws on initialization

### DIFF
--- a/test_nodelet/src/failing_nodelet.cpp
+++ b/test_nodelet/src/failing_nodelet.cpp
@@ -30,6 +30,7 @@
 #include <pluginlib/class_list_macros.hpp>
 #include <nodelet/nodelet.h>
 #include <ros/ros.h>
+#include <std_msgs/Bool.h>
 
 namespace test_nodelet
 {
@@ -43,8 +44,12 @@ public:
 private:
   virtual void onInit()
   {
+    m_publisher = getPrivateNodeHandle().advertise<std_msgs::Bool>("boolean", 5, false);
     throw std::runtime_error("Initialization error");
   }
+
+private:
+  ros::Publisher m_publisher;
 };
 
 PLUGINLIB_EXPORT_CLASS(test_nodelet::FailingNodelet, nodelet::Nodelet)


### PR DESCRIPTION
When a nodelet thrown on initialization while using a CallbackQueue (e.g. by having a subscriber), the nodelet was deleted after the CallbackQueue, resulting in a use-after-free of the queue when deleting the nodelet.

This was because the NodeletPtr in `Loader::load` was deleted *after* the `ManagedNodelet`, which holds the CallbackQueues. Fix this by moving the NodeletPtr into the ManagedNodelet.

We also could call `NodeletPtr::reset` in the catch.

Closes #121.